### PR TITLE
Display tooltip on hover

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -16,7 +16,7 @@ const Tooltip = ({
 
   const css = `
     .Tooltip_box { display: none }
-    .Tooltip:hover .Tooltip-box { display: block }
+    .Tooltip:hover .Tooltip_box { display: block }
   `.replace(/\n/g, '').replace(/\s\s+/g, ' ')
 
   const sx = {
@@ -45,7 +45,7 @@ const Tooltip = ({
       left: '50%',
       border: '6px solid transparent',
       borderTopColor: colors.black,
-      transform: 'translate(-50%, 4px)'
+      transform: 'translate(-50%, 0)'
     }
   }
 


### PR DESCRIPTION
This PR fixes to actually show the `<Tooltip />` component on hover.

Not sure why those 4px are set but this creates a space between the arrow and the tooltip box so I'll removed it too.