### PR TITLE
Merge this.props.classNames into component's className

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
+node_modules/
 dist
 

--- a/src/Arrow.js
+++ b/src/Arrow.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /** Arrow for use in dropdowns and other UI elements */
 
@@ -8,7 +9,7 @@ const Arrow = ({ direction, children, ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Arrow'
+      className={mergeClassName(props, 'Arrow')}
       baseStyle={{
         display: 'inline-block',
         width: 0,

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
-
+import mergeClassName from './util/mergeClassName'
 /**
  * A circular image for displaying user avatars
  */
@@ -18,7 +18,7 @@ const Avatar = ({
     <Base
       {...props}
       tagName='img'
-      className='Avatar'
+      className={mergeClassName(props, 'Avatar')}
       width={size}
       height={size}
       baseStyle={{

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /** Component for displaying small status indicators */
 
@@ -28,7 +29,7 @@ const Badge = ({ ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Badge'
+      className={mergeClassName(props, 'Badge')}
       inverted
       baseStyle={sx} />
   )

--- a/src/Banner.js
+++ b/src/Banner.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
-
+import mergeClassName from './util/mergeClassName'
 /**
  * Full-height banner with styling for background images
  */
@@ -42,7 +42,7 @@ const Banner = ({
   return (
     <Base
       {...props}
-      className='Banner'
+      className={mergeClassName(props, 'Banner')}
       baseStyle={sx} />
   )
 }

--- a/src/Block.js
+++ b/src/Block.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Generic box with visual styling
@@ -34,7 +35,7 @@ const Block = ({
 
   return (
     <Base {...props}
-      className='Block'
+      className={mergeClassName(props, 'Block')}
       baseStyle={sx} />
   )
 }

--- a/src/Blockquote.js
+++ b/src/Blockquote.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Stylized blockquote element with citation link
@@ -39,7 +40,7 @@ const Blockquote = ({
     <Base
       {...props}
       tagName='blockquote'
-      className='Blockquote'
+      className={mergeClassName(props, 'Blockquote')}
       baseStyle={sx.root}>
       <p style={sx.p}>
         {children}

--- a/src/Breadcrumbs.js
+++ b/src/Breadcrumbs.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Breadcrumb navigation links
@@ -30,7 +31,7 @@ const Breadcrumbs = ({
   return (
     <Base
       {...props}
-      className='Breadcrumbs'
+      className={mergeClassName(props, 'Breadcrumbs')}
       baseStyle={sx.root}>
       {links.map((link, i) => (
         <div key={i}>

--- a/src/Button.js
+++ b/src/Button.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * A general purpose button element with customizable colors
@@ -43,7 +44,7 @@ const Button = ({
     <Base
       {...props}
       tagName={Component}
-      className={_className || 'Button'}
+      className={mergeClassName(props, _className || 'Button')}
       href={href}
       baseStyle={sx}/>
   )

--- a/src/Card.js
+++ b/src/Card.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Styled box with border
@@ -26,7 +27,7 @@ const Card = ({
   return (
     <Base
       {...props}
-      className='Card'
+      className={mergeClassName(props, 'Card')}
       baseStyle={sx} />
   )
 }

--- a/src/CardImage.js
+++ b/src/CardImage.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Image for use within the Card component
@@ -18,7 +19,7 @@ const CardImage = ({
     <Base
       {...props}
       tagName='img'
-      className='CardImage'
+      className={mergeClassName(props, 'CardImage')}
       src={src}
       baseStyle={{
         display: 'block',

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -4,6 +4,7 @@ import classnames from 'classnames'
 import Base from './Base'
 import Label from './Label'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Checkbox input with label
@@ -77,7 +78,7 @@ const Checkbox = ({
     <Base
       {...props}
       tagName={Label}
-      className={cx}
+      className={mergeClassName(props, cx)}
       baseStyle={sx.root}>
       <input
         {...props}

--- a/src/Close.js
+++ b/src/Close.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * A button with an × for close and dismiss actions
@@ -10,7 +11,7 @@ const Close = ({ ...props }, { rebass }) => {
   return (
     <Base {...props}
       tagName='button'
-      className='Close'
+      className={mergeClassName(props, 'Close')}
       title='Close'
       baseStyle={{
         fontSize: '1.5em',

--- a/src/Container.js
+++ b/src/Container.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Div with max-width and margin auto for centering content
@@ -13,7 +14,7 @@ const Container = ({ ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Container'
+      className={mergeClassName(props, 'Container')}
       baseStyle={{
         maxWidth: 1024,
         paddingLeft: scale[2],

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Styled hr element
@@ -17,7 +18,7 @@ const Divider = ({
     <Base
       {...props}
       tagName='hr'
-      className='Divider'
+      className={mergeClassName(props, 'Divider')}
       baseStyle={{
         width,
         marginTop: scale[2],

--- a/src/Donut.js
+++ b/src/Donut.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 const M = 'M'
 const A = 'A'
@@ -105,7 +106,7 @@ const Donut = ({
 
   return (
     <Base {...props}
-      className='Donut'
+      className={mergeClassName(props, 'Donut')}
       baseStyle={sx.root}>
       <svg
         xmlns='http://www.w3.org/svg/2000'

--- a/src/DotIndicator.js
+++ b/src/DotIndicator.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Dot indicator buttons for use in carousels
@@ -55,7 +56,7 @@ const DotIndicator = ({
   return (
     <Base
       {...props}
-      className='DotIndicator'
+      className={mergeClassName(props, 'DotIndicator')}
       baseStyle={sx.root}>
       {dots.map((d) => (
         <button

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * An off-canvas drawer component
@@ -83,12 +84,12 @@ const Drawer = ({
   }
 
   return (
-    <div className='Drawer'>
+    <div className={mergeClassName(props, 'Drawer')}>
       <div style={sx.dismiss}
         onClick={onDismiss} />
       <Base
         {...props}
-        className='Drawer Drawer_content'
+        className={mergeClassName(props, 'Drawer Drawer_content')}
         baseStyle={sx.content} />
     </div>
   )

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Position relative container for positioning DropdownMenu component
@@ -9,7 +10,7 @@ import Base from './Base'
 const Dropdown = ({ ...props }) => (
   <Base
     {...props}
-    className='Dropdown'
+    className={mergeClassName(props, 'Dropdown')}
     baseStyle={{
       position: 'relative'
     }} />

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Base from './Base'
 import Menu from './Menu'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Absolutely positioned Menu component for use within Dropdown component
@@ -45,7 +46,7 @@ const DropdownMenu = ({
   return (
     <Base
       {...props}
-      className='DropdownMenu'
+      className={mergeClassName(props, 'DropdownMenu')}
       baseStyle={sx.root}>
       <div style={sx.overlay}
         onClick={onDismiss} />

--- a/src/Embed.js
+++ b/src/Embed.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Responsive media embed wrapper
@@ -26,7 +27,7 @@ const Embed = ({ ratio, children, ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Embed'
+      className={mergeClassName(props, 'Embed')}
       children={styledChildren}
       baseStyle={{
         position: 'relative',

--- a/src/Fixed.js
+++ b/src/Fixed.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Layout container for fixed positioning children
@@ -25,7 +26,7 @@ const Fixed = ({
 
   return (
     <Base {...props}
-      className='Fixed'
+      className={mergeClassName(props, 'Fixed')}
       baseStyle={sx} />
   )
 }

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Minimal footer component with top border
@@ -14,7 +15,7 @@ const Footer = ({ ...props }, { rebass }) => {
     <Base
       {...props}
       tagName='footer'
-      className='Footer'
+      className={mergeClassName(props, 'Footer')}
       baseStyle={{
         display: 'flex',
         flexWrap: 'wrap',

--- a/src/Heading.js
+++ b/src/Heading.js
@@ -3,6 +3,7 @@ import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Heading element with no margin and size based on fontSizes scale
@@ -37,7 +38,7 @@ const Heading = ({
     <Base
       {...props}
       tagName={Component}
-      className={cx}
+      className={mergeClassName(props, cx)}
       baseStyle={{
         fontSize,
         fontWeight: bold,

--- a/src/HeadingLink.js
+++ b/src/HeadingLink.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Heading from './Heading'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Heading element with unstyled link. Useful for in-page navigation

--- a/src/InlineForm.js
+++ b/src/InlineForm.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Input from './Input'
 import ButtonOutline from './ButtonOutline'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Inline grouped form for search or other simple forms
@@ -34,7 +35,7 @@ const InlineForm = ({
   return (
     <Base {...props}
       tagName='form'
-      className='InlineForm'
+      className={mergeClassName(props, 'InlineForm')}
       baseStyle={sx.root}>
       <Input
         name={name}

--- a/src/Input.js
+++ b/src/Input.js
@@ -5,6 +5,7 @@ import Base from './Base'
 import Label from './Label'
 import Text from './Text'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Input element with label with support for aria-invalid, disabled, and readOnly HTML attributes
@@ -61,7 +62,7 @@ const Input = ({
   return (
     <Base
       {...rootProps}
-      className={cx}
+      className={mergeClassName(props, cx)}
       baseStyle={sx.root}>
       <Label
         htmlFor={name}

--- a/src/Label.js
+++ b/src/Label.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Label element for form controls
@@ -25,7 +26,7 @@ const Label = ({
     <Base
       {...props}
       tagName='label'
-      className='Label'
+      className={mergeClassName(props, 'Label')}
       baseStyle={{
         fontSize: fontSizes[5],
         fontWeight: bold,

--- a/src/LinkBlock.js
+++ b/src/LinkBlock.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import Base from './Base'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Unstyled display block link
@@ -20,7 +21,7 @@ const LinkBlock = ({
     <Base
       {...props}
       tagName={Component}
-      className='LinkBlock'
+      className={mergeClassName(props, 'LinkBlock')}
       baseStyle={sx} />
   )
 }

--- a/src/Media.js
+++ b/src/Media.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Media object with vertical alignment using flexbox
@@ -27,7 +28,7 @@ const Media = ({
   return (
     <Base
       {...props}
-      className='Media'
+      className={mergeClassName(props, 'Media')}
       baseStyle={{
         display: 'flex',
         marginBottom: scale[2],

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Menu component for navigation links and actions
@@ -13,7 +14,7 @@ const Menu = ({ ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Menu'
+      className={mergeClassName(props, 'Menu')}
       baseStyle={{
         display: 'flex',
         flexDirection: 'column',

--- a/src/Message.js
+++ b/src/Message.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /** Component for displaying flash and error messages */
 
@@ -11,7 +12,7 @@ const Message = ({ ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Message'
+      className={mergeClassName(props, 'Message')}
       baseStyle={{
         fontWeight: bold,
         display: 'flex',

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Link for use in navigation. Inherits color
@@ -21,7 +22,7 @@ const NavItem = ({
     <Base
       {...props}
       tagName={Component}
-      className='NavItem'
+      className={mergeClassName(props, 'NavItem')}
       baseStyle={{
         fontSize: small ? fontSizes[6] : fontSizes[5],
         fontWeight: bold,

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Fixed positioned overlay for use with modal dialogs
@@ -57,7 +58,7 @@ const Overlay = ({
 
   return (
     <div
-      className='Overlay'
+      className={mergeClassName(props, 'Overlay')}
       style={sx.root}>
       <div style={sx.dismiss}
         onClick={onDismiss} />

--- a/src/PageHeader.js
+++ b/src/PageHeader.js
@@ -4,6 +4,7 @@ import Base from './Base'
 import Heading from './Heading'
 import Text from './Text'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Main page header with description
@@ -21,7 +22,7 @@ const PageHeader = ({
     <Base
       {...props}
       tagName='header'
-      className='PageHeader'
+      className={mergeClassName(props, 'PageHeader')}
       baseStyle={{
         display: 'flex',
         flexWrap: 'wrap',

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Panel for containing small pieces of information
@@ -22,7 +23,7 @@ const Panel = ({ theme, children, ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Panel'
+      className={mergeClassName(props, 'Panel')}
       baseStyle={{
         padding: scale[2],
         marginBottom: scale[2],

--- a/src/PanelFooter.js
+++ b/src/PanelFooter.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Footer for Panel component with vertical centering using flexbox
@@ -14,7 +15,7 @@ const PanelFooter = ({ theme, ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='PanelFooter'
+      className={mergeClassName(props, 'PanelFooter')}
       baseStyle={{
         fontSize: fontSizes[6],
         display: 'flex',

--- a/src/PanelHeader.js
+++ b/src/PanelHeader.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Header for Panel component with vertical centering using flexbox
@@ -13,7 +14,7 @@ const PanelHeader = ({ ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='PanelHeader'
+      className={mergeClassName(props, 'PanelHeader')}
       inverted
       baseStyle={{
         display: 'flex',

--- a/src/Pre.js
+++ b/src/Pre.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Pre element for displaying code examples
@@ -14,7 +15,7 @@ const Pre = ({ ...props }, { rebass }) => {
     <Base
       {...props}
       tagName='pre'
-      className='Pre'
+      className={mergeClassName(props, 'Pre')}
       baseStyle={{
         fontFamily: monospace,
         paddingLeft: scale[2],

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Progress element
@@ -43,7 +44,7 @@ const Progress = ({ value, ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Progress'
+      className={mergeClassName(props, 'Progress')}
       baseStyle={sx.root}>
       <style dangerouslySetInnerHTML={{ __html: css }} />
       <progress

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -4,6 +4,7 @@ import classnames from 'classnames'
 import Base from './Base'
 import Label from './Label'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Styled custom radio input with label
@@ -67,7 +68,7 @@ const Radio = ({
     <Base
       {...props}
       tagName={Label}
-      className={cx}
+      className={mergeClassName(props, cx)}
       baseStyle={sx.root}>
       <input
         {...props}

--- a/src/Rating.js
+++ b/src/Rating.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Star rating component with clickable buttons
@@ -66,7 +67,7 @@ const Rating = ({
   return (
     <Base
       {...props}
-      className='Rating'
+      className={mergeClassName(props, 'Rating')}
       baseStyle={sx.root}>
       {stars.map((s) => (
         <button

--- a/src/Section.js
+++ b/src/Section.js
@@ -2,6 +2,8 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import classNames from 'classnames/dedupe'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Section element with vertical padding
@@ -14,7 +16,7 @@ const Section = ({ ...props }, { rebass }) => {
     <Base
       {...props}
       tagName='section'
-      className='Section'
+      className={mergeClassName(props, 'Section')}
       baseStyle={{
         paddingTop: scale[4],
         paddingBottom: scale[4]

--- a/src/SectionHeader.js
+++ b/src/SectionHeader.js
@@ -4,6 +4,7 @@ import Base from './Base'
 import HeadingLink from './HeadingLink'
 import Text from './Text'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Header for section elements
@@ -22,7 +23,7 @@ const SectionHeader = ({
     <Base
       {...props}
       tagName='header'
-      className='SectionHeader'
+      className={mergeClassName(props, 'SectionHeader')}
       baseStyle={{
         display: 'flex',
         alignItems: 'center',

--- a/src/Select.js
+++ b/src/Select.js
@@ -6,6 +6,7 @@ import Label from './Label'
 import Text from './Text'
 import Arrow from './Arrow'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Select form control with label
@@ -74,7 +75,7 @@ const Select = ({
   return (
     <Base
       {...rootProps}
-      className={cx}
+      className={mergeClassName(props, cx)}
       baseStyle={sx.root}>
       <Label
         htmlFor={name}

--- a/src/SequenceMap.js
+++ b/src/SequenceMap.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Base from './Base'
 import SequenceMapStep from './SequenceMapStep'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Sequence map pattern for use in multi-step forms
@@ -44,7 +45,7 @@ const SequenceMap = ({
     <Base
       {...props}
       children={chx || schx}
-      className='SequenceMap'
+      className={mergeClassName(props, 'SequenceMap')}
       baseStyle={sx} />
   )
 }

--- a/src/SequenceMapStep.js
+++ b/src/SequenceMapStep.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import LinkBlock from './LinkBlock'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Subcomponent for use in SequenceMap

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -3,6 +3,7 @@ import React from 'react'
 import Label from './Label'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Stylized range input with label
@@ -45,7 +46,7 @@ const Slider = ({
   return (
     <Base
       {...props}
-      className='Slider'
+      className={mergeClassName(props, 'Slider')}
       baseStyle={{
         paddingBottom: scale[2]
       }}>

--- a/src/Space.js
+++ b/src/Space.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Inline-block element for adding space between elements
@@ -13,7 +14,7 @@ const Space = ({ x, auto, children, ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Space'
+      className={mergeClassName(props, 'Space')}
       baseStyle={{
         display: 'inline-block',
         flex: auto ? '1 1 auto' : null,

--- a/src/Stat.js
+++ b/src/Stat.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Styled number display for statistics
@@ -41,7 +42,7 @@ const Stat = ({
   return (
     <Base
       {...props}
-      className='Stat'
+      className={mergeClassName(props, 'Stat')}
       baseStyle={sx.root}>
       {topLabel && <div style={sx.label}>{label}</div>}
       <div style={sx.value}>

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Binary toggle switch component
@@ -44,7 +45,7 @@ const Switch = ({
   return (
     <Base
       {...props}
-      className='Switch'
+      className={mergeClassName(props, 'Switch')}
       role='checkbox'
       aria-checked={checked}
       baseStyle={sx.root}>

--- a/src/Table.js
+++ b/src/Table.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Table element with simplified props
@@ -52,7 +53,7 @@ const Table = ({
   return (
     <Base
       {...props}
-      className='Table'
+      className={mergeClassName(props, 'Table')}
       baseStyle={sx.root}>
       <table style={sx.table}>
         <thead style={sx.thead}>

--- a/src/Text.js
+++ b/src/Text.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Component for displaying text in UI
@@ -18,7 +19,7 @@ const Text = ({
     <Base
       {...props}
       tagName='p'
-      className='Text'
+      className={mergeClassName(props, 'Text')}
       baseStyle={{
         fontSize: small ? fontSizes[6] : fontSizes[4],
         fontWeight: bold ? b : null,

--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -5,6 +5,7 @@ import Base from './Base'
 import Label from './Label'
 import Text from './Text'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Textarea form element with label
@@ -56,7 +57,7 @@ const Textarea = ({
   return (
     <Base
       {...rootProps}
-      className={cx}
+      className={mergeClassName(props, cx)}
       baseStyle={sx.root}>
       <Label
         htmlFor={name}

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Toolbar component that vertically centers children with display flex
@@ -13,7 +14,7 @@ const Toolbar = ({ ...props }, { rebass }) => {
   return (
     <Base
       {...props}
-      className='Toolbar'
+      className={mergeClassName(props, 'Toolbar')}
       baseStyle={{
         display: 'flex',
         alignItems: 'center',

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import Base from './Base'
 import config from './config'
+import mergeClassName from './util/mergeClassName'
 
 /**
  * Styled tooltip that shows on hover
@@ -51,7 +52,7 @@ const Tooltip = ({
 
   return (
     <span
-      className='Tooltip'
+      className={mergeClassName(props, 'Tooltip')}
       title={title}
       style={sx.root}>
       <style dangerouslySetInnerHTML={{ __html: css }} />

--- a/src/util/mergeClassName.js
+++ b/src/util/mergeClassName.js
@@ -3,7 +3,7 @@
  */
 
 function merge (props, className) {
-  return [props, className].join(' ').trim()
+  return [props.className, className].join(' ').trim()
 }
 
 export default merge

--- a/src/util/mergeClassName.js
+++ b/src/util/mergeClassName.js
@@ -1,0 +1,10 @@
+/**
+ * Utility for merge class name from props from components
+ */
+
+function merge (props, className) {
+  return [props, className].join(' ').trim()
+}
+
+export default merge
+


### PR DESCRIPTION
The internal rendering of a component has fully ignored the className definition on the component. That caused that we couldn't use className as our styling or theming method anymore on rebus component.

And I also added `node_modules/` into .gitignore.