### PR TITLE
Improves browser compatibility by adding react inline auto prefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "homepage": "https://github.com/jxnblk/rebass",
   "dependencies": {
+    "auto-prefixer": "^0.4.2",
     "classnames": "^2.2.3",
     "object-assign": "^4.0.1"
   },

--- a/src/Base.js
+++ b/src/Base.js
@@ -1,6 +1,7 @@
 
 import React from 'react'
 import assign from 'object-assign'
+import autoprefix from 'auto-prefixer'
 import margins from './util/margins'
 import padding from './util/padding'
 import radii from './util/radii'
@@ -39,7 +40,7 @@ const Base = ({
     style
   )
 
-  return <Component {...props} style={sx} />
+  return <Component {...props} style={autoprefix(sx)} />
 }
 
 Base.propTypes = {

--- a/src/SequenceMapStep.js
+++ b/src/SequenceMapStep.js
@@ -1,5 +1,6 @@
 
 import React from 'react'
+import autoprefix from 'auto-prefixer'
 import LinkBlock from './LinkBlock'
 import config from './config'
 
@@ -62,7 +63,7 @@ const SequenceMapStep = ({
       }}
       {...props}>
       <div style={sx.dot} />
-      {!first && <div style={sx.line} />}
+      {!first && <div style={autoprefix(sx.line)} />}
       <div style={sx.label}>
         {children}
       </div>


### PR DESCRIPTION
Adds auto-prefixer for inline react styles to improve browser compatibility.
SequenceMap now displays properly in Chrome and Safari

https://github.com/yonatanmn/react-inline-auto-prefixer