### PR TITLE
Exposing Base to Breadcrumbs links

### DIFF
--- a/src/Breadcrumbs.js
+++ b/src/Breadcrumbs.js
@@ -34,7 +34,9 @@ const Breadcrumbs = ({
       baseStyle={sx.root}>
       {links.map((link, i) => (
         <div key={i}>
-          <a {...link}
+          <Base
+            is='a'
+            {...link}
             style={{
               color: 'inherit',
               textDecoration: i === links.length - 1 ? 'none' : null

--- a/test/Breadcrumbs.spec.js
+++ b/test/Breadcrumbs.spec.js
@@ -34,7 +34,8 @@ describe('Breadcrumbs', () => {
 
     it('should have one link', () => {
       expect(tree.props.children.length).toEqual(1)
-      expect(tree.props.children[0].props.children[0].type).toEqual('a')
+      expect(tree.props.children[0].props.children[0].type).toEqual(Base)
+      expect(tree.props.children[0].props.children[0].props.is).toEqual('a')
     })
 
     it('should not have a separator', () => {


### PR DESCRIPTION
I want to be able to do something like this:

```js
import { Link } from 'react-router'

<Breadcrumbs
  links={[
    { children: 'Home', is: Link, to: '/' },
    { children: 'Services', is: Link, to: '/services' },
    { children: title, is: Link, to: `/${path}` }
  ]}
/>
```