### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
+node_modules
 dist
 build
 demo/bundle.js
-


### PR DESCRIPTION
Hi,

I thought it might be a good idea to add ```node_modules``` to the [.gitignore] (https://github.com/jxnblk/rebass/blob/master/.gitignore) file.

Greetz,
boristian