### PR TITLE
feat(nested styles): Add nested style definitions

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -118,6 +118,7 @@ class Base extends React.Component {
       baseStyle,
       style,
       baseRef,
+      parentName,
       ...props
     } = this.props
 
@@ -125,7 +126,11 @@ class Base extends React.Component {
     const { scale, colors, borderRadius } = { ...config, ...rebass }
     const name = props.className
     const keys = name ? name.split(' ') : []
-    const contextStyle = keys.reduce((a, key) => (assign(a, (rebass ? rebass[key] : {}))), {})
+    // Ignore the case where tagName and className are not explicitly set as the path Name.div is not terribly useful.
+    if (parentName && (name || tagName)) {
+      keys.push(parentName + '.' + (name || tagName))
+    }
+    const contextStyle = keys.reduce((a, key) => (assign(a, key.split('.').reduce((result, subKey) => (result[subKey] || {}), (rebass || {})))), {})
 
     const Component = is || props.Component || tagName || 'div'
 
@@ -157,4 +162,3 @@ class Base extends React.Component {
 }
 
 export default Base
-

--- a/src/Input.js
+++ b/src/Input.js
@@ -80,7 +80,8 @@ const Input = ({
     }
   }
 
-  const cx = classnames('Input', {
+  const className = 'Input'
+  const cx = classnames(className, {
     'isInvalid': invalid,
     'isDisabled': props.disabled,
     'isReadonly': props.readOnly
@@ -100,16 +101,18 @@ const Input = ({
       baseStyle={sx.root}>
       <Label
         htmlFor={name}
+        parentName={className}
         hide={hideLabel}
         children={label} />
       <Base
         {...autoProps}
         {...props}
+        parentName={className}
         tagName='input'
         type={type}
         name={name}
         baseStyle={sx.input} />
-      {message && <Text small children={message} />}
+      {message && <Text small children={message} parentName={className} />}
     </Base>
   )
 }
@@ -149,4 +152,3 @@ Input.contextTypes = {
 }
 
 export default Input
-

--- a/test/Base.spec.js
+++ b/test/Base.spec.js
@@ -115,6 +115,66 @@ describe('Base', () => {
     })
   })
 
+  context('when context, className and parentName is set', () => {
+    beforeEach(() => {
+      renderer.render(<Base className='Test' parentName='Parent' />, {
+        rebass: {
+          Test: {
+            color: 'red',
+            backgroundColor: 'tomato'
+          },
+          Parent: {
+            Test: { backgroundColor: 'white' }
+          }
+        }
+      })
+      tree = renderer.getRenderOutput()
+    })
+
+    it('should set background color', () => {
+      expect(tree.props.style.backgroundColor).toEqual('white')
+    })
+
+    it('should set color', () => {
+      expect(tree.props.style.color).toEqual('red')
+    })
+  })
+
+  context('when context, tagName and parentName is set and className is not set', () => {
+    beforeEach(() => {
+      renderer.render(<Base tagName='Test' parentName='Parent' />, {
+        rebass: {
+          Parent: {
+            Test: { backgroundColor: 'white' }
+          }
+        }
+      })
+      tree = renderer.getRenderOutput()
+    })
+
+    it('should set background color', () => {
+      expect(tree.props.style.backgroundColor).toEqual('white')
+    })
+  })
+
+  context('when context, tagName, className and parentName is set', () => {
+    beforeEach(() => {
+      renderer.render(<Base className='Test' tagName='tag' parentName='Parent' />, {
+        rebass: {
+          Parent: {
+            Test: { backgroundColor: 'white' },
+            tag: {backgroundColor: 'blue'}
+          }
+        }
+      })
+      tree = renderer.getRenderOutput()
+    })
+
+    it('should prioritise className value over tagName', () => {
+      expect(tree.props.style.backgroundColor).toEqual('white')
+    })
+  })
+
   context('when baseStyle is set', () => {
     beforeEach(() => {
       renderer.render(<Base baseStyle={{ backgroundColor: 'tomato' }} />)
@@ -645,4 +705,3 @@ describe('Base', () => {
     })
   })
 })
-


### PR DESCRIPTION
For example setting the following rebass context:
```
rebass = {
  Input: {
    input: {
      color: ‘blue’
    }
  }
}
```
would set `color: ‘blue’` on the `input` element of the `Input` component. Only done for Input as a first pass. In the code I use the `parentName` attribute to declare what the calling component is, this allows us to figure on the chain and retrieve it from rebass.

Related to solution for #71.