### PR TITLE
Allow for setting Menu & DropdownMenu styles separately

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -14,6 +14,8 @@ const DropdownMenu = ({
   top,
   children,
   onDismiss,
+  dropdownMenuStyle,
+  menuStyle,
   ...props
 }, { rebass }) => {
   const { zIndex } = { ...config, ...rebass }
@@ -46,11 +48,13 @@ const DropdownMenu = ({
     <Base
       {...props}
       className='DropdownMenu'
-      baseStyle={sx.root}>
+      baseStyle={{...dropdownMenuStyle, ...sx.root}}>
       <div style={sx.overlay}
         onClick={onDismiss} />
       <div style={sx.content}>
-        <Menu {...props}
+        <Menu
+          {...props}
+          baseStyle={menuStyle}
           children={children} />
       </div>
     </Base>
@@ -65,7 +69,11 @@ DropdownMenu.propTypes = {
   /** Anchors menu to the top */
   top: React.PropTypes.bool,
   /** Click event callback for the background overlay */
-  onDismiss: React.PropTypes.func
+  onDismiss: React.PropTypes.func,
+  /** Styles specific to the dropdown menu <Base> component */
+  dropdownMenuStyle: React.PropTypes.object,
+  /** Styles specific to the <Menu> component */
+  menuStyle: React.PropTypes.object
 }
 
 DropdownMenu.defaultProps = {
@@ -78,4 +86,3 @@ DropdownMenu.contextTypes = {
 }
 
 export default DropdownMenu
-

--- a/test/DropdownMenu.js
+++ b/test/DropdownMenu.js
@@ -75,5 +75,30 @@ describe('DropdownMenu', () => {
       expect(tree.props.style.color).toEqual('tomato')
     })
   })
-})
 
+  context('when custom styles for DropdownMenu are set', () => {
+    beforeEach(() => {
+      renderer.render(<DropdownMenu dropdownMenuStyle={{ color: 'tomato' }} />)
+      tree = renderer.getRenderOutput()
+    })
+
+    it('should have a custom color only for the top component', () => {
+      expect(tree.props.baseStyle.color).toEqual('tomato')
+      expect(tree.props.children[1].props.children.props.baseStyle)
+        .toNotExist()
+    })
+  })
+
+  context('when custom styles for Menu are set', () => {
+    beforeEach(() => {
+      renderer.render(<DropdownMenu menuStyle={{ color: 'tomato' }} />)
+      tree = renderer.getRenderOutput()
+    })
+
+    it('should have a custom color only for the menu component', () => {
+      expect(tree.props.children[1].props.children.props.baseStyle.color)
+        .toEqual('tomato')
+      expect(tree.props.baseStyle.color).toNotExist()
+    })
+  })
+})


### PR DESCRIPTION
Hi! I read the CONTRIBUTING.md and I think I followed
the guidelines to the best of my abilities. I started trying
out the library after stumbling across your project basscss,
and so far I'm loving it 😄 .

With that out of the way, here's some of the issues I encountered:
passing `style` to any element works perfectly, but when
it comes to `DropdownMenu`, it has `Menu` inside as
well. The problem comes when trying to style said menu - 
styles get applied to both the container `div` and the
`Menu`'s `div`. I'm not sure if this is an actual problem to
anyone but it prevents me from using it. I haven't found
another way to send styles specifically to `Menu` other
than overwriting the entire component via `getChildContext`,
which seems way overkill and screws with other dropdowns
that might not necessarily need those styles.
