### PR TITLE
add make large a overlay scrollable

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -51,6 +51,7 @@ const Overlay = ({
       zIndex: zIndex[1],
       minWidth: 320,
       width: fullWidth ? '100%' : null,
+      overflow: 'scroll',
       ...(box ? innerStyle : {})
     }
   }


### PR DESCRIPTION
Currently the Overlay isn't scrollable if the content is too high.
The fix is to add overflow: scroll on the "inner" div.
