### PR TITLE
Add showDefaultPercentage prop to Donut

### DIFF
--- a/src/Donut.js
+++ b/src/Donut.js
@@ -65,6 +65,7 @@ const Donut = ({
   size,
   strokeWidth,
   children,
+  showDefaultPercentage,
   ...props
 }, { rebass }) => {
   const { bold } = { ...config, ...rebass }
@@ -116,7 +117,7 @@ const Donut = ({
         <path d={createPath(size, value, strokeWidth)} />
       </svg>
       {children}
-      {!children &&
+      {!children && showDefaultPercentage &&
         <span style={sx.percentage}>
           {Math.round(value * 100)}
           <span style={sx.unit}>%</span>
@@ -134,14 +135,17 @@ Donut.propTypes = {
   /** Sets width of stroke */
   strokeWidth: React.PropTypes.number,
   /** Text color - can either be a key from the config colors object or any color value */
-  color: React.PropTypes.string
+  color: React.PropTypes.string,
+  /** If true does not display default percentage */
+  showDefaultPercentage: React.PropTypes.bool
 }
 
 Donut.defaultProps = {
   value: 0,
   size: 128,
   strokeWidth: 8,
-  color: 'primary'
+  color: 'primary',
+  showDefaultPercentage: true
 }
 
 Donut.contextTypes = {

--- a/test/Donut.spec.js
+++ b/test/Donut.spec.js
@@ -108,6 +108,17 @@ describe('Donut', () => {
     })
   })
 
+  context('when showDefaultPercentage is set to false', () => {
+    beforeEach(() => {
+      renderer.render(<Donut value={1 / 4} showDefaultPercentage={false} />)
+      tree = renderer.getRenderOutput()
+      percentage = tree.props.children[1]
+    })
+    it('should not show value as perecentage', () => {
+      expect(percentage).toNotExist()
+    })
+  })
+
   context('when custom styles are set', () => {
     beforeEach(() => {
       renderer.render(<Donut style={{ color: 'tomato' }} />)


### PR DESCRIPTION
Add `showDefaultPercentage` prop to Donut that if set to false leaves the center of the donut empty. 

Currently we have to do the following to accomplish this. 

``` jsx
<Donut value={percentageComplete}>
  {' '}
</Donut> 
```

I am not sure if the Donut component is designed this way intentionally and is always meant to have a value displayed in the center, but we use it with just the indicator and the format below would be much cleaner than than the current one shown above.

``` jsx
<Donut value={percentageComplete} showDefaultPercentage={false} />
```

Edit: Not sure if this is the best name, could also see using `hideDefaultPercentage` or `hidePercentage`. These may make more sense, lemme know your preference and I can update if you are going to accept the PR.  
