### PR TITLE
Pass color prop to Base in Slider

### DIFF
--- a/src/Slider.js
+++ b/src/Slider.js
@@ -15,6 +15,7 @@ const Slider = ({
   hideLabel,
   children,
   style,
+  color,
   m,
   mt,
   mr,
@@ -39,6 +40,7 @@ const Slider = ({
 
   const rootProps = {
     style,
+    color,
     m,
     mt,
     mr,


### PR DESCRIPTION
Pass the `color` property to `Base` for the `Slider` component so that custom colors passed in are transformed using `color-style`. 

Somewhat (loosely) related to https://github.com/jxnblk/rebass/issues/163
