### PR TITLE
Changed prop type of buttonLabel in InlineForm to oneOfType([element,string])

### DIFF
--- a/src/InlineForm.js
+++ b/src/InlineForm.js
@@ -74,8 +74,11 @@ InlineForm.propTypes = {
   placeholder: React.PropTypes.string,
   /** onChange handler for input */
   onChange: React.PropTypes.func,
-  /** Text for button */
-  buttonLabel: React.PropTypes.string,
+  /** Text or element for button */
+  buttonLabel: React.PropTypes.oneOfType([
+    React.PropTypes.element,
+    React.PropTypes.string
+  ]),
   /** onClick handler for button */
   onClick: React.PropTypes.func
 }


### PR DESCRIPTION
I think it would be cool to have possibility to pass element to buttonLabel so we can use something like font-awesome in it:

``` jsx
const iconElement = style => (<i className={style} />);
...
<InlineForm
    buttonLabel={iconElement('fa fa-search')}
    label="Search"
    name="search_form"
    placeholder="SEARCH"
  />
```
