### PR TITLE
Use default cursor on disabled radio inputs

### DIFF
--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -73,7 +73,7 @@ const Checkbox = ({
       flexDirection: stacked ? 'column' : null,
       paddingBottom: scale[1],
       color: invalid ? colors.error : null,
-      cursor: 'pointer'
+      cursor: props.disabled ? 'inherit' : 'pointer'
     },
     input: {
       position: 'absolute',

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -73,7 +73,7 @@ const Radio = ({
       flexDirection: stacked ? 'column' : null,
       paddingBottom: scale[1],
       color: invalid ? colors.error : null,
-      cursor: 'pointer'
+      cursor: props.disabled ? 'inherit' : 'pointer'
     },
     input: {
       position: 'absolute',


### PR DESCRIPTION
Stumbled on a minor UI issue through https://github.com/alleyinteractive/simplechart/issues/60.

Currently `label` associated to `radio` input will get the `pointer` cursor style regardless of `disabled` state.

This patch switches to `inherit` as the cursor style when the `radio` input is `disabled`.

Tested with mocha and in our app. Thanks for any feedback.