### PR TITLE
Fix inverted property behavior for PanelHeader

### DIFF
--- a/src/PanelHeader.js
+++ b/src/PanelHeader.js
@@ -14,7 +14,6 @@ const PanelHeader = (props, { rebass }) => {
     <Base
       {...props}
       className='PanelHeader'
-      inverted
       baseStyle={{
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
`inverted` is already being set to true in the default props and explicitly setting it to true like this makes it impossible to override with a value form props.