### PR TITLE
Idea: Change Input PropType from 'string' to 'node'

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -116,7 +116,7 @@ const Input = ({
 
 Input.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: React.PropTypes.node.isRequired,
   /** Name attribute for form element */
   name: React.PropTypes.string.isRequired,
   /** Form element type */


### PR DESCRIPTION
<img width="1267" alt="screen shot 2016-12-14 at 2 23 36 pm" src="https://cloud.githubusercontent.com/assets/693878/21197288/f0b4f5fc-c208-11e6-9c1d-87bffc140844.png">

Thanks for the awesome library! 

I have a small idea. Think it sounds ok?

Sometimes when I'm implementing a react app I want to use something other than a text string inside an input's label. According to the [HTML `label` specification](http://www.w3.org/TR/html5/forms.html#the-label-element) a label can contain "[phrasing content](https://www.w3.org/TR/html5/dom.html#phrasing-content-1)" which includes things like `span`, `a`, `strong`, and `small`.

**Would it be strictly wrong to change `Input.propTypes.label` to be "any node" instead of just "a string"?** It looks to me like the library already works in a way that allows any React node to be passed in as the prop as you can see in the screenshot above, so changing the propType validation would simply codify that this is allowed.