### PR TITLE
Update childContextTypes usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ To configure the theme, add `childContextTypes` and `getChildContext` to your ro
 
 ```jsx
 class App extends React.Component {
-  static childContextTypes = {
-    rebass: React.PropTypes.object
-  }
-
   getChildContext () {
     return {
       rebass: {
@@ -93,6 +89,10 @@ class App extends React.Component {
   render () {
     // ...
   }
+}
+
+App.childContextTypes = {
+  rebass: React.PropTypes.object
 }
 ```
 


### PR DESCRIPTION
The example provided uses [Stage-2 tc39 proposal](https://github.com/tc39/proposal-class-public-fields) syntax and it fails when you don't have `stage-x` presets in the babel config. The code can be replaced with code that doesn't need these presets - taken from [React docs](https://facebook.github.io/react/docs/context.html#how-to-use-context).