### PR TITLE
React.PropTypes -> prop-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ View the [demo](http://jxnblk.com/rebass/demo) to see some configuration options
 To configure the theme, add `childContextTypes` and `getChildContext` to your root component.
 
 ```jsx
+import React from 'react'
+import PropTypes from 'prop-types'
+
 class App extends React.Component {
   getChildContext () {
     return {
@@ -88,7 +91,7 @@ class App extends React.Component {
 }
 
 App.childContextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 ```
 

--- a/demo/components/App.js
+++ b/demo/components/App.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import jsonp from 'jsonp'
 import assign from 'object-assign'
@@ -61,7 +62,7 @@ class App extends React.Component {
   }
 
   static childContextTypes = {
-    rebass: React.PropTypes.object
+    rebass: PropTypes.object
   }
 
   getChildContext () {

--- a/demo/components/Forms.js
+++ b/demo/components/Forms.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import assign from 'object-assign'
 import { Flex, Box } from 'reflexbox'
@@ -51,7 +52,7 @@ class Forms extends React.Component {
   }
 
   static childContextTypes = {
-    rebass: React.PropTypes.object
+    rebass: PropTypes.object
   }
 
   getChildContext () {
@@ -221,7 +222,7 @@ class Forms extends React.Component {
 }
 
 Forms.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Forms

--- a/docs/components/PropsTable.js
+++ b/docs/components/PropsTable.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 
 const PropsTable = ({ props, ...other }) => {
@@ -85,7 +86,7 @@ const PropsTable = ({ props, ...other }) => {
 }
 
 PropsTable.propTypes = {
-  props: React.PropTypes.object
+  props: PropTypes.object
 }
 
 export default PropsTable

--- a/docs/components/Root.js
+++ b/docs/components/Root.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import { Flex, Box } from 'reflexbox'
 import {
@@ -42,7 +43,7 @@ class Root extends React.Component {
   }
 
   static childContextTypes = {
-    rebass: React.PropTypes.object
+    rebass: PropTypes.object
   }
 
   getChildContext () {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "mocha-jsdom": "^1.1.0",
     "object-assign": "^4.1.0",
     "onchange": "^3.2.1",
-    "react": "^15.4.2",
+    "react": "^15.5.4",
     "react-addons-test-utils": "^15.4.2",
     "react-component-permutations": "^1.0.0-beta2",
     "react-docgen": "^2.13.0",
-    "react-dom": "^15.4.2",
+    "react-dom": "^15.5.4",
     "react-element-to-jsx-string": "^6.0.0",
     "react-geomicons": "^2.0.5",
     "react-router": "^3.0.2",
@@ -56,6 +56,7 @@
   "dependencies": {
     "classnames": "^2.2.3",
     "object-assign": "^4.1.1",
+    "prop-types": "^15.5.8",
     "react-addons-pure-render-mixin": "^15.4.2"
   },
   "keywords": [

--- a/src/Arrow.js
+++ b/src/Arrow.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 
@@ -25,7 +26,7 @@ const Arrow = ({ direction, children, ...props }, { rebass }) => {
 
 Arrow.propTypes = {
   /** Direction of arrow */
-  direction: React.PropTypes.oneOf(['up', 'down'])
+  direction: PropTypes.oneOf(['up', 'down'])
 }
 
 Arrow.defaultProps = {
@@ -33,7 +34,7 @@ Arrow.defaultProps = {
 }
 
 Arrow.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Arrow

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -33,7 +34,7 @@ const Avatar = ({
 
 Avatar.propTypes = {
   /** Width and height of image in pixels */
-  size: React.PropTypes.number
+  size: PropTypes.number
 }
 
 Avatar.defaultProps = {
@@ -42,7 +43,7 @@ Avatar.defaultProps = {
 }
 
 Avatar.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Avatar

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -36,7 +37,7 @@ const Badge = (props, { rebass }) => {
 
 Badge.propTypes = {
   /** Sets color based on theme */
-  theme: React.PropTypes.oneOf([
+  theme: PropTypes.oneOf([
     'primary',
     'secondary',
     'default',
@@ -46,9 +47,9 @@ Badge.propTypes = {
     'error'
   ]),
   /** Controls border radius */
-  rounded: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.oneOf([
+  rounded: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf([
       'top',
       'right',
       'bottom',
@@ -56,9 +57,9 @@ Badge.propTypes = {
     ])
   ]),
   /** Sets pill style border radii */
-  pill: React.PropTypes.bool,
+  pill: PropTypes.bool,
   /** Sets width and border radius for circular badges */
-  circle: React.PropTypes.bool
+  circle: PropTypes.bool
 }
 
 Badge.defaultProps = {
@@ -67,7 +68,7 @@ Badge.defaultProps = {
 }
 
 Badge.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Badge

--- a/src/Banner.js
+++ b/src/Banner.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -49,9 +50,9 @@ const Banner = ({
 
 Banner.propTypes = {
   /** Horizontal alignment */
-  align: React.PropTypes.oneOf(['left', 'center', 'right']),
+  align: PropTypes.oneOf(['left', 'center', 'right']),
   /** Background image source */
-  backgroundImage: React.PropTypes.string
+  backgroundImage: PropTypes.string
 }
 
 Banner.defaultProps = {
@@ -59,7 +60,7 @@ Banner.defaultProps = {
 }
 
 Banner.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Banner

--- a/src/Base.js
+++ b/src/Base.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import PureRenderMixin from 'react-addons-pure-render-mixin'
 import assign from 'object-assign'
@@ -26,7 +27,7 @@ class Base extends React.Component {
   }
 
   static contextTypes = {
-    rebass: React.PropTypes.object
+    rebass: PropTypes.object
   }
 
   static defaultProps = {
@@ -35,56 +36,56 @@ class Base extends React.Component {
 
   static propTypes = {
     /** HTML element string or React component to render */
-    tagName: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func,
-      React.PropTypes.element
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
+      PropTypes.element
     ]),
     /** Used to pull styles from the rebass context object */
-    className: React.PropTypes.string,
+    className: PropTypes.string,
     /** Base component styles */
-    baseStyle: React.PropTypes.object,
+    baseStyle: PropTypes.object,
     /** Styles from component instance - overrides base and context styles */
-    style: React.PropTypes.object,
+    style: PropTypes.object,
     /** Function to obtain refs for the underlying Base component */
-    baseRef: React.PropTypes.func,
+    baseRef: PropTypes.func,
 
     /** Applies margin with the margin utility based on the spacing scale */
-    m: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    m: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies margin top based on the spacing scale */
-    mt: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    mt: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies margin right based on the spacing scale */
-    mr: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    mr: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies margin bottom based on the spacing scale */
-    mb: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    mb: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies margin left based on the spacing scale */
-    ml: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    ml: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies margin left and right based on the spacing scale */
-    mx: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    mx: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies margin top and bottom based on the spacing scale */
-    my: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    my: PropTypes.oneOf([0, 1, 2, 3, 4]),
 
     /** Applies padding with the padding utility based on the spacing scale */
-    p: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    p: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies padding top based on the spacing scale */
-    pt: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    pt: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies padding right based on the spacing scale */
-    pr: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    pr: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies padding bottom based on the spacing scale */
-    pb: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    pb: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies padding left based on the spacing scale */
-    pl: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    pl: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies padding left and right based on the spacing scale */
-    px: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    px: PropTypes.oneOf([0, 1, 2, 3, 4]),
     /** Applies padding top and bottom based on the spacing scale */
-    py: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+    py: PropTypes.oneOf([0, 1, 2, 3, 4]),
 
     /** Text color - can either be a key from the config colors object or any color value */
-    color: React.PropTypes.string,
+    color: PropTypes.string,
     /** Background color - can either be a key from the config colors object or any color value */
-    backgroundColor: React.PropTypes.string,
+    backgroundColor: PropTypes.string,
     /** Sets color from config */
-    theme: React.PropTypes.oneOf([
+    theme: PropTypes.oneOf([
       'primary',
       'secondary',
       'default',
@@ -94,11 +95,11 @@ class Base extends React.Component {
       'error'
     ]),
     /** Inverts colors from theme */
-    inverted: React.PropTypes.bool,
+    inverted: PropTypes.bool,
     /** Controls border radius */
-    rounded: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.oneOf([
+    rounded: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.oneOf([
         'top',
         'right',
         'bottom',
@@ -106,9 +107,9 @@ class Base extends React.Component {
       ])
     ]),
     /** Sets border radius 99999 */
-    circle: React.PropTypes.bool,
+    circle: PropTypes.bool,
     /** Sets border radius 99999 */
-    pill: React.PropTypes.bool
+    pill: PropTypes.bool
   }
 
   render () {

--- a/src/Block.js
+++ b/src/Block.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -44,71 +45,71 @@ const Block = ({
 
 Block.propTypes = {
   /** Text color - can either be a key from the config colors object or any color value */
-  color: React.PropTypes.string,
+  color: PropTypes.string,
   /** Background color - can either be a key from the config colors object or any color value */
-  backgroundColor: React.PropTypes.string,
+  backgroundColor: PropTypes.string,
   /** Border color - can either be a key from the config colors object or any color value */
-  borderColor: React.PropTypes.string,
+  borderColor: PropTypes.string,
   /** Adds a border */
-  border: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number
+  border: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number
   ]),
   /** Adds a border to the top side */
-  borderTop: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number
+  borderTop: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number
   ]),
   /** Adds a border to the right side */
-  borderRight: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number
+  borderRight: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number
   ]),
   /** Adds a border to the bottom side */
-  borderBottom: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number
+  borderBottom: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number
   ]),
   /** Adds a border to the left side */
-  borderLeft: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.number
+  borderLeft: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.number
   ]),
 
   /** Applies margin with the margin utility based on the spacing scale */
-  m: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  m: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies margin top based on the spacing scale */
-  mt: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  mt: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies margin right based on the spacing scale */
-  mr: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  mr: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies margin bottom based on the spacing scale */
-  mb: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  mb: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies margin left based on the spacing scale */
-  ml: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  ml: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies margin left and right based on the spacing scale */
-  mx: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  mx: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies margin top and bottom based on the spacing scale */
-  my: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  my: PropTypes.oneOf([0, 1, 2, 3, 4]),
 
   /** Applies padding with the padding utility based on the spacing scale */
-  p: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  p: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies padding top based on the spacing scale */
-  pt: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  pt: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies padding right based on the spacing scale */
-  pr: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  pr: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies padding bottom based on the spacing scale */
-  pb: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  pb: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies padding left based on the spacing scale */
-  pl: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  pl: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies padding left and right based on the spacing scale */
-  px: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  px: PropTypes.oneOf([0, 1, 2, 3, 4]),
   /** Applies padding top and bottom based on the spacing scale */
-  py: React.PropTypes.oneOf([0, 1, 2, 3, 4]),
+  py: PropTypes.oneOf([0, 1, 2, 3, 4]),
 
   /** Controls border radius */
-  rounded: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.oneOf([
+  rounded: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf([
       'top',
       'right',
       'bottom',
@@ -118,7 +119,7 @@ Block.propTypes = {
 }
 
 Block.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Block

--- a/src/Blockquote.js
+++ b/src/Blockquote.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -56,9 +57,9 @@ const Blockquote = ({
 
 Blockquote.propTypes = {
   /** Name of source */
-  source: React.PropTypes.string,
+  source: PropTypes.string,
   /** URL link to source */
-  href: React.PropTypes.string
+  href: PropTypes.string
 }
 
 export default Blockquote

--- a/src/Breadcrumbs.js
+++ b/src/Breadcrumbs.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -52,7 +53,7 @@ const Breadcrumbs = ({
 
 Breadcrumbs.propTypes = {
   /** Array of link props */
-  links: React.PropTypes.array.isRequired
+  links: PropTypes.array.isRequired
 }
 
 Breadcrumbs.defaultProps = {
@@ -60,7 +61,7 @@ Breadcrumbs.defaultProps = {
 }
 
 Breadcrumbs.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Breadcrumbs

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -51,15 +52,15 @@ const Button = ({
 
 Button.propTypes = {
   /** Pass an href prop to make the Button an <a> tag instead of a <button> */
-  href: React.PropTypes.string,
+  href: PropTypes.string,
   /** Button color - can either be a key from the config colors object or any color value */
-  color: React.PropTypes.string,
+  color: PropTypes.string,
   /** Background color - can either be a key from the config colors object or any color value */
-  backgroundColor: React.PropTypes.string,
+  backgroundColor: PropTypes.string,
   /** Controls the border radius for creating button groups */
-  rounded: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.oneOf([
+  rounded: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf([
       'top',
       'right',
       'bottom',
@@ -67,11 +68,11 @@ Button.propTypes = {
     ])
   ]),
   /** Creates a pill style button */
-  pill: React.PropTypes.bool,
+  pill: PropTypes.bool,
   /** Creates a larger button */
-  big: React.PropTypes.bool,
+  big: PropTypes.bool,
   /** Sets color from config */
-  theme: React.PropTypes.oneOf([
+  theme: PropTypes.oneOf([
     'primary',
     'secondary',
     'default',
@@ -90,7 +91,7 @@ Button.defaultProps = {
 }
 
 Button.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Button

--- a/src/ButtonCircle.js
+++ b/src/ButtonCircle.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Button from './Button'
 import config from './config'
@@ -46,17 +47,17 @@ const ButtonCircle = ({
 
 ButtonCircle.propTypes = {
   /** Pass an href prop to make the ButtonCircle an <a> tag instead of a <button> */
-  href: React.PropTypes.string,
+  href: PropTypes.string,
   /** Text color - can either be a key from the config colors object or any color value */
-  color: React.PropTypes.string,
+  color: PropTypes.string,
   /** Background color - can either be a key from the config colors object or any color value */
-  backgroundColor: React.PropTypes.string,
+  backgroundColor: PropTypes.string,
   /** Sets width and height of button */
-  size: React.PropTypes.number
+  size: PropTypes.number
 }
 
 ButtonCircle.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default ButtonCircle

--- a/src/ButtonOutline.js
+++ b/src/ButtonOutline.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Button from './Button'
 
@@ -28,13 +29,13 @@ const ButtonOutline = ({
 
 ButtonOutline.propTypes = {
   /** Pass an href prop to make the ButtonOutline an <a> tag instead of a <button> */
-  href: React.PropTypes.string,
+  href: PropTypes.string,
   /** Text color */
-  color: React.PropTypes.string,
+  color: PropTypes.string,
   /** Controls the border radius for creating button groups */
-  rounded: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.oneOf([
+  rounded: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf([
       'top',
       'right',
       'bottom',
@@ -42,9 +43,9 @@ ButtonOutline.propTypes = {
     ])
   ]),
   /** Creates a pill style button */
-  pill: React.PropTypes.bool,
+  pill: PropTypes.bool,
   /** Creates a larger button */
-  big: React.PropTypes.bool
+  big: PropTypes.bool
 }
 
 ButtonOutline.defaultProps = {
@@ -54,7 +55,7 @@ ButtonOutline.defaultProps = {
 }
 
 ButtonOutline.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default ButtonOutline

--- a/src/Card.js
+++ b/src/Card.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -33,9 +34,9 @@ const Card = ({
 
 Card.propTypes = {
   /** Width of card */
-  width: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
+  width: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
   ])
 }
 
@@ -44,7 +45,7 @@ Card.defaultProps = {
 }
 
 Card.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Card

--- a/src/CardImage.js
+++ b/src/CardImage.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -33,11 +34,11 @@ const CardImage = ({
 
 CardImage.propTypes = {
   /** Image source */
-  src: React.PropTypes.string.isRequired
+  src: PropTypes.string.isRequired
 }
 
 CardImage.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default CardImage

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
@@ -139,11 +140,11 @@ const Checkbox = ({
 
 Checkbox.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Name attribute for form element */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Place label centered under the radio */
-  stacked: React.PropTypes.bool
+  stacked: PropTypes.bool
 }
 
 export default Checkbox

--- a/src/Close.js
+++ b/src/Close.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 
@@ -29,7 +30,7 @@ const Close = (props, { rebass }) => {
 }
 
 Close.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Close

--- a/src/Container.js
+++ b/src/Container.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -24,7 +25,7 @@ const Container = (props, { rebass }) => {
 }
 
 Container.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Container

--- a/src/Divider.js
+++ b/src/Divider.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -32,11 +33,11 @@ const Divider = ({
 
 Divider.propTypes = {
   /** Sets a fixed width for stylistic options */
-  width: React.PropTypes.number
+  width: PropTypes.number
 }
 
 Divider.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Divider

--- a/src/Donut.js
+++ b/src/Donut.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -128,13 +129,13 @@ const Donut = ({
 
 Donut.propTypes = {
   /** Value from 0 to 1 */
-  value: React.PropTypes.number,
+  value: PropTypes.number,
   /** Sets width and height */
-  size: React.PropTypes.number,
+  size: PropTypes.number,
   /** Sets width of stroke */
-  strokeWidth: React.PropTypes.number,
+  strokeWidth: PropTypes.number,
   /** Text color - can either be a key from the config colors object or any color value */
-  color: React.PropTypes.string
+  color: PropTypes.string
 }
 
 Donut.defaultProps = {
@@ -145,7 +146,7 @@ Donut.defaultProps = {
 }
 
 Donut.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Donut

--- a/src/DotIndicator.js
+++ b/src/DotIndicator.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -74,11 +75,11 @@ const DotIndicator = ({
 
 DotIndicator.propTypes = {
   /** Number of dot buttons to show */
-  length: React.PropTypes.number,
+  length: PropTypes.number,
   /** Index of the currently active dot */
-  active: React.PropTypes.number,
+  active: PropTypes.number,
   /** Click event callback - returns index of clicked button */
-  onClick: React.PropTypes.func
+  onClick: PropTypes.func
 }
 
 DotIndicator.defaultProps = {
@@ -86,7 +87,7 @@ DotIndicator.defaultProps = {
 }
 
 DotIndicator.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default DotIndicator

--- a/src/Drawer.js
+++ b/src/Drawer.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -96,18 +97,18 @@ const Drawer = ({
 
 Drawer.propTypes = {
   /** Width or height of drawer, depending on placement */
-  size: React.PropTypes.number,
+  size: PropTypes.number,
   /** Shows and hides the drawer */
-  open: React.PropTypes.bool,
+  open: PropTypes.bool,
   /** Position relative to the viewport */
-  position: React.PropTypes.oneOf([
+  position: PropTypes.oneOf([
     'top',
     'right',
     'bottom',
     'left'
   ]),
   /** Click event callback for the background overlay */
-  onDismiss: React.PropTypes.func
+  onDismiss: PropTypes.func
 }
 
 Drawer.defaultProps = {
@@ -120,7 +121,7 @@ Drawer.defaultProps = {
 }
 
 Drawer.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Drawer

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import Menu from './Menu'
@@ -59,13 +60,13 @@ const DropdownMenu = ({
 
 DropdownMenu.propTypes = {
   /** Toggles visibility of DropdownMenu */
-  open: React.PropTypes.bool,
+  open: PropTypes.bool,
   /** Anchors menu to the right */
-  right: React.PropTypes.bool,
+  right: PropTypes.bool,
   /** Anchors menu to the top */
-  top: React.PropTypes.bool,
+  top: PropTypes.bool,
   /** Click event callback for the background overlay */
-  onDismiss: React.PropTypes.func
+  onDismiss: PropTypes.func
 }
 
 DropdownMenu.defaultProps = {
@@ -74,7 +75,7 @@ DropdownMenu.defaultProps = {
 }
 
 DropdownMenu.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default DropdownMenu

--- a/src/Embed.js
+++ b/src/Embed.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 
@@ -44,7 +45,7 @@ Embed.propTypes = {
    * Divide height over width to calculate.
    * E.g. ratio={9/16}
    */
-  ratio: React.PropTypes.number
+  ratio: PropTypes.number
 }
 
 Embed.defaultProps = {
@@ -52,7 +53,7 @@ Embed.defaultProps = {
 }
 
 Embed.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Embed

--- a/src/Fixed.js
+++ b/src/Fixed.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 
@@ -32,15 +33,15 @@ const Fixed = ({
 
 Fixed.propTypes = {
   /** Sets top: 0 */
-  top: React.PropTypes.bool,
+  top: PropTypes.bool,
   /** Sets right: 0 */
-  right: React.PropTypes.bool,
+  right: PropTypes.bool,
   /** Sets bottom: 0 */
-  bottom: React.PropTypes.bool,
+  bottom: PropTypes.bool,
   /** Sets left: 0 */
-  left: React.PropTypes.bool,
+  left: PropTypes.bool,
   /** Sets z-index */
-  zIndex: React.PropTypes.number
+  zIndex: PropTypes.number
 }
 
 export default Fixed

--- a/src/Footer.js
+++ b/src/Footer.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -31,7 +32,7 @@ const Footer = (props, { rebass }) => {
 }
 
 Footer.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Footer

--- a/src/Heading.js
+++ b/src/Heading.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
@@ -50,13 +51,13 @@ const Heading = ({
 
 Heading.propTypes = {
   /** Doubles the visual size - useful for marketing pages */
-  big: React.PropTypes.bool,
+  big: PropTypes.bool,
   /** Heading level, e.g. level={1} for <h1> */
-  level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   /** Visual size of heading */
-  size: React.PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
+  size: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6]),
   /** Applies alternate styling - useful for slugs and subheadings */
-  alt: React.PropTypes.bool
+  alt: PropTypes.bool
 }
 
 Heading.defaultProps = {
@@ -64,7 +65,7 @@ Heading.defaultProps = {
 }
 
 Heading.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Heading

--- a/src/HeadingLink.js
+++ b/src/HeadingLink.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Heading from './Heading'
 
@@ -26,11 +27,11 @@ const HeadingLink = ({ level, size, href, style, ...props }, { rebass }) => {
 
 HeadingLink.propTypes = {
   /** Heading level, e.g. level={1} for <h1> */
-  level: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  level: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   /** Visual size of heading */
-  size: React.PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
+  size: PropTypes.oneOf([1, 2, 3, 4, 5, 6]),
   /** href for link */
-  href: React.PropTypes.string
+  href: PropTypes.string
 }
 
 HeadingLink.defaultProps = {
@@ -39,7 +40,7 @@ HeadingLink.defaultProps = {
 }
 
 HeadingLink.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default HeadingLink

--- a/src/InlineForm.js
+++ b/src/InlineForm.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Input from './Input'
 import ButtonOutline from './ButtonOutline'
@@ -57,30 +58,30 @@ const InlineForm = ({
 }
 
 InlineForm.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 InlineForm.propTypes = {
   /** Input label */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Input name */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Input value */
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
   ]),
   /** Input placeholder */
-  placeholder: React.PropTypes.string,
+  placeholder: PropTypes.string,
   /** onChange handler for input */
-  onChange: React.PropTypes.func,
+  onChange: PropTypes.func,
   /** Text or element for button */
-  buttonLabel: React.PropTypes.oneOfType([
-    React.PropTypes.element,
-    React.PropTypes.string
+  buttonLabel: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string
   ]),
   /** onClick handler for button */
-  onClick: React.PropTypes.func
+  onClick: PropTypes.func
 }
 
 InlineForm.defaultProps = {

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
@@ -116,21 +117,21 @@ const Input = ({
 
 Input.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Name attribute for form element */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Form element type */
-  type: React.PropTypes.string,
+  type: PropTypes.string,
   /** Adds a helper or error message below the input */
-  message: React.PropTypes.string,
+  message: PropTypes.string,
   /** Hides the form element label */
-  hideLabel: React.PropTypes.bool,
+  hideLabel: PropTypes.bool,
   /** Disables autocomplete, autocorrect, autocapitalize, and spellcheck props */
-  autoOff: React.PropTypes.bool,
+  autoOff: PropTypes.bool,
   /** Controls the border radius for creating grouped elements */
-  rounded: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.oneOf([
+  rounded: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.oneOf([
       'top',
       'right',
       'bottom',
@@ -145,7 +146,7 @@ Input.defaultProps = {
 }
 
 Input.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Input

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -39,11 +40,11 @@ Label.propTypes = {
   /** Accessibly hide label for use in high density UI.
    *  This can still cause accessibility issues. Use this with caution.
    */
-  hide: React.PropTypes.bool
+  hide: PropTypes.bool
 }
 
 Label.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Label

--- a/src/LinkBlock.js
+++ b/src/LinkBlock.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 
@@ -26,10 +27,10 @@ const LinkBlock = ({
 
 LinkBlock.propTypes = {
   /** Root component - useful for use with react-router's Link component */
-  is: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-    React.PropTypes.func
+  is: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.func
   ])
 }
 
@@ -38,7 +39,7 @@ LinkBlock.defaultProps = {
 }
 
 LinkBlock.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default LinkBlock

--- a/src/Media.js
+++ b/src/Media.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -48,15 +49,15 @@ const Media = ({
 
 Media.propTypes = {
   /** Image source */
-  img: React.PropTypes.string,
+  img: PropTypes.string,
   /** Displays image to the right */
-  right: React.PropTypes.bool,
+  right: PropTypes.bool,
   /** Vertical alignment */
-  align: React.PropTypes.oneOf(['top', 'center', 'bottom'])
+  align: PropTypes.oneOf(['top', 'center', 'bottom'])
 }
 
 Media.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Media

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -35,7 +36,7 @@ Menu.defaultProps = {
 }
 
 Menu.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Menu

--- a/src/Message.js
+++ b/src/Message.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -24,7 +25,7 @@ const Message = (props, { rebass }) => {
 
 Message.propTypes = {
   /** Sets color from config */
-  theme: React.PropTypes.oneOf([
+  theme: PropTypes.oneOf([
     'primary',
     'secondary',
     'default',
@@ -42,7 +43,7 @@ Message.defaultProps = {
 }
 
 Message.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Message

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -37,12 +38,12 @@ const NavItem = ({
 
 NavItem.propTypes = {
   /** Sets a smaller font size for compact UI */
-  small: React.PropTypes.bool,
+  small: PropTypes.bool,
   /** Root component - useful for use with react-router's Link component */
-  is: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.object,
-    React.PropTypes.func
+  is: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.func
   ])
 }
 
@@ -51,7 +52,7 @@ NavItem.defaultProps = {
 }
 
 NavItem.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default NavItem

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -71,15 +72,15 @@ const Overlay = ({
 
 Overlay.propTypes = {
   /** Shows and hides overlay */
-  open: React.PropTypes.bool,
+  open: PropTypes.bool,
   /** Sets dark transparent overlay style */
-  dark: React.PropTypes.bool,
+  dark: PropTypes.bool,
   /** Sets padding and background white for the content container */
-  box: React.PropTypes.bool,
+  box: PropTypes.bool,
   /** Sets content container full width */
-  fullWidth: React.PropTypes.bool,
+  fullWidth: PropTypes.bool,
   /** Click event callback for the Overlay background */
-  onDismiss: React.PropTypes.func
+  onDismiss: PropTypes.func
 }
 
 Overlay.defaultProps = {
@@ -89,7 +90,7 @@ Overlay.defaultProps = {
 }
 
 Overlay.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Overlay

--- a/src/PageHeader.js
+++ b/src/PageHeader.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import Heading from './Heading'
@@ -47,13 +48,13 @@ const PageHeader = ({
 
 PageHeader.propTypes = {
   /** Page heading */
-  heading: React.PropTypes.string,
+  heading: PropTypes.string,
   /** Description of page */
-  description: React.PropTypes.string
+  description: PropTypes.string
 }
 
 PageHeader.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default PageHeader

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -38,7 +39,7 @@ const Panel = ({ theme, children, ...props }, { rebass }) => {
 
 Panel.propTypes = {
   /** Sets color from config */
-  theme: React.PropTypes.oneOf([
+  theme: PropTypes.oneOf([
     'primary',
     'secondary',
     'default',
@@ -54,7 +55,7 @@ Panel.defaultProps = {
 }
 
 Panel.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Panel

--- a/src/PanelFooter.js
+++ b/src/PanelFooter.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -34,7 +35,7 @@ const PanelFooter = ({ theme, ...props }, { rebass }) => {
 
 PanelFooter.propTypes = {
   /** Sets color based on theme */
-  theme: React.PropTypes.oneOf([
+  theme: PropTypes.oneOf([
     'primary',
     'secondary',
     'default',
@@ -50,7 +51,7 @@ PanelFooter.defaultProps = {
 }
 
 PanelFooter.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default PanelFooter

--- a/src/PanelHeader.js
+++ b/src/PanelHeader.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -30,7 +31,7 @@ const PanelHeader = (props, { rebass }) => {
 
 PanelHeader.propTypes = {
   /** Sets color from config */
-  theme: React.PropTypes.oneOf([
+  theme: PropTypes.oneOf([
     'primary',
     'secondary',
     'default',
@@ -47,7 +48,7 @@ PanelHeader.defaultProps = {
 }
 
 PanelHeader.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default PanelHeader

--- a/src/Pre.js
+++ b/src/Pre.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -26,7 +27,7 @@ const Pre = (props, { rebass }) => {
 }
 
 Pre.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Pre

--- a/src/Progress.js
+++ b/src/Progress.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -58,9 +59,9 @@ const Progress = ({ value, ...props }, { rebass }) => {
 
 Progress.propTypes = {
   /** Value for progress bar */
-  value: React.PropTypes.number,
+  value: PropTypes.number,
   /** Bar color - can either be a key from the config colors object or any color value */
-  color: React.PropTypes.string
+  color: PropTypes.string
 }
 
 Progress.defaultProps = {
@@ -68,7 +69,7 @@ Progress.defaultProps = {
 }
 
 Progress.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Progress

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
@@ -123,11 +124,11 @@ const Radio = ({
 
 Radio.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Name attribute for form element */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Place label centered under the radio */
-  stacked: React.PropTypes.bool
+  stacked: PropTypes.bool
 }
 
 Radio.defaultProps = {
@@ -135,7 +136,7 @@ Radio.defaultProps = {
 }
 
 Radio.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Radio

--- a/src/Rating.js
+++ b/src/Rating.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -83,9 +84,9 @@ const Rating = ({
 
 Rating.propTypes = {
   /** Number of star rating from 1 to 5 */
-  value: React.PropTypes.number,
+  value: PropTypes.number,
   /** Click handler - returns index of star clicked */
-  onClick: React.PropTypes.func
+  onClick: PropTypes.func
 }
 
 Rating.defaultProps = {
@@ -94,7 +95,7 @@ Rating.defaultProps = {
 }
 
 Rating.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Rating

--- a/src/Section.js
+++ b/src/Section.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -23,7 +24,7 @@ const Section = (props, { rebass }) => {
 }
 
 Section.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Section

--- a/src/SectionHeader.js
+++ b/src/SectionHeader.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import HeadingLink from './HeadingLink'
@@ -47,15 +48,15 @@ const SectionHeader = ({
 
 SectionHeader.propTypes = {
   /** Section heading */
-  heading: React.PropTypes.string,
+  heading: PropTypes.string,
   /** Link to section, used in HeadingLink */
-  href: React.PropTypes.string,
+  href: PropTypes.string,
   /** Description of section */
-  description: React.PropTypes.string
+  description: PropTypes.string
 }
 
 SectionHeader.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default SectionHeader

--- a/src/Select.js
+++ b/src/Select.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
@@ -126,15 +127,15 @@ const Select = ({
 
 Select.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Name attribute for form element */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Options for select */
-  options: React.PropTypes.array.isRequired,
+  options: PropTypes.array.isRequired,
   /** Adds a helper or error message below the select */
-  message: React.PropTypes.string,
+  message: PropTypes.string,
   /** Hides the form element label */
-  hideLabel: React.PropTypes.bool
+  hideLabel: PropTypes.bool
 }
 
 Select.defaultProps = {
@@ -143,7 +144,7 @@ Select.defaultProps = {
 }
 
 Select.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Select

--- a/src/SequenceMap.js
+++ b/src/SequenceMap.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import SequenceMapStep from './SequenceMapStep'
@@ -50,14 +51,14 @@ const SequenceMap = ({
 }
 
 SequenceMap.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 SequenceMap.propTypes = {
   /** Array of links for each step in the sequence */
-  steps: React.PropTypes.array,
+  steps: PropTypes.array,
   /** Index of current step */
-  active: React.PropTypes.number
+  active: PropTypes.number
 }
 
 SequenceMap.defaultProps = {

--- a/src/SequenceMapStep.js
+++ b/src/SequenceMapStep.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import LinkBlock from './LinkBlock'
 import config from './config'
@@ -71,16 +72,16 @@ const SequenceMapStep = ({
 }
 
 SequenceMapStep.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 SequenceMapStep.propTypes = {
   /** Width of step */
-  width: React.PropTypes.string,
+  width: PropTypes.string,
   /** Removes line from first step */
-  first: React.PropTypes.bool,
+  first: PropTypes.bool,
   /** Sets primary color on active step */
-  active: React.PropTypes.bool
+  active: PropTypes.bool
 }
 
 export default SequenceMapStep

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Label from './Label'
 import Base from './Base'
@@ -119,17 +120,17 @@ const Slider = ({
 
 Slider.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Name attribute for form element */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Adds a fill color to the track - requires client-side JavaScript */
-  fill: React.PropTypes.bool,
+  fill: PropTypes.bool,
   /** Hides the form element label */
-  hideLabel: React.PropTypes.bool
+  hideLabel: PropTypes.bool
 }
 
 Slider.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Slider

--- a/src/Space.js
+++ b/src/Space.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -24,9 +25,9 @@ const Space = ({ x, auto, children, ...props }, { rebass }) => {
 
 Space.propTypes = {
   /** Width of space based on the spacing scale */
-  x: React.PropTypes.oneOf([1, 2, 3, 4]),
+  x: PropTypes.oneOf([1, 2, 3, 4]),
   /** Sets flex: 1 1 auto */
-  auto: React.PropTypes.bool
+  auto: PropTypes.bool
 }
 
 Space.defaultProps = {
@@ -34,7 +35,7 @@ Space.defaultProps = {
 }
 
 Space.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Space

--- a/src/Stat.js
+++ b/src/Stat.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -55,20 +56,20 @@ const Stat = ({
 
 Stat.propTypes = {
   /** Value for stat shown in large font size */
-  value: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.string
+  value: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
   ]),
   /** Optional unit for displaying next to value */
-  unit: React.PropTypes.string,
+  unit: PropTypes.string,
   /** Label for stat */
-  label: React.PropTypes.string,
+  label: PropTypes.string,
   /** Displays label above value */
-  topLabel: React.PropTypes.bool
+  topLabel: PropTypes.bool
 }
 
 Stat.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Stat

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -55,11 +56,11 @@ const Switch = ({
 
 Switch.propTypes = {
   /** Sets the Switch to an active style */
-  checked: React.PropTypes.bool
+  checked: PropTypes.bool
 }
 
 Switch.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Switch

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -83,9 +84,9 @@ const Table = ({
 
 Table.propTypes = {
   /** Headings for <th> */
-  headings: React.PropTypes.array,
+  headings: PropTypes.array,
   /** Array of table row data for <td> */
-  data: React.PropTypes.arrayOf(React.PropTypes.array)
+  data: PropTypes.arrayOf(PropTypes.array)
 }
 
 Table.defaultProps = {
@@ -94,7 +95,7 @@ Table.defaultProps = {
 }
 
 Table.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Table

--- a/src/Text.js
+++ b/src/Text.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -29,13 +30,13 @@ const Text = ({
 
 Text.propTypes = {
   /** Sets a smaller font size */
-  small: React.PropTypes.bool,
+  small: PropTypes.bool,
   /** Sets bold font weight */
-  bold: React.PropTypes.bool
+  bold: PropTypes.bool
 }
 
 Text.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Text

--- a/src/Textarea.js
+++ b/src/Textarea.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import classnames from 'classnames'
 import Base from './Base'
@@ -100,13 +101,13 @@ const Textarea = ({
 
 Textarea.propTypes = {
   /** Label for form element */
-  label: React.PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   /** Name attribute for form element */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
   /** Adds a helper or error message below the textarea */
-  message: React.PropTypes.string,
+  message: PropTypes.string,
   /** Hides the form element label */
-  hideLabel: React.PropTypes.bool
+  hideLabel: PropTypes.bool
 }
 
 Textarea.defaultProps = {
@@ -114,7 +115,7 @@ Textarea.defaultProps = {
 }
 
 Textarea.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Textarea

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -27,7 +28,7 @@ const Toolbar = (props, { rebass }) => {
 }
 
 Toolbar.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Toolbar

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,4 +1,5 @@
 
+import PropTypes from 'prop-types'
 import React from 'react'
 import Base from './Base'
 import config from './config'
@@ -68,7 +69,7 @@ const Tooltip = ({
 
 Tooltip.propTypes = {
   /** Text to display in tooltip */
-  title: React.PropTypes.string
+  title: PropTypes.string
 }
 
 Tooltip.defaultProps = {
@@ -77,7 +78,7 @@ Tooltip.defaultProps = {
 }
 
 Tooltip.contextTypes = {
-  rebass: React.PropTypes.object
+  rebass: PropTypes.object
 }
 
 export default Tooltip


### PR DESCRIPTION
v15.5.0 of react adds a [deprecation warning for `React.PropTypes`](https://facebook.github.io/react/blog/#migrating-from-react.proptypes).

```
▶ Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.
```

Instead we're encouraged to install the separate `prop-types` package and use PropTypes from there.

```js
import PropTypes from 'prop-types';
```

This PR adds upgrades the version of react in the `devDependencies`, adds `prop-types` to the deps, and updates all components to use the `prop-types` package instead of `React.PropTypes`.