### PR TITLE
Make Toolbar background black

### DIFF
--- a/docs/examples/Toolbar.jsx
+++ b/docs/examples/Toolbar.jsx
@@ -1,4 +1,4 @@
-<Toolbar>
+<Toolbar bg='black'>
   <NavLink>
     Hello
   </NavLink>


### PR DESCRIPTION
The Toolbar demo is currently invisible because of the white text color, so this PR makes the background black.