### PR TITLE
Fix typo in Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ import { Provider, Heading, Button } from 'rebass'
 
 const App = props => (
   <Provider>
-    <Heading>Hello<Heading>
+    <Heading>Hello</Heading>
     <Button>Rebass</Button>
   </Provider>
 )


### PR DESCRIPTION
The closing tag for `<Header>` was missing a forward-slash. 🤓 