### PR TITLE
Support multiple font weight props

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,25 @@ simple and helps promote consistent design.
 <Text f={3} />
 ```
 
+### Font Weight
+
+Like`fontSize`, the `fontWeight` prop allows you to easily reference steps on the weights scale.
+
+```jsx
+// Numbers are used to reference steps on the weights scale
+// i.e. the `theme.weights` array
+<Text fontWeight={1} />
+
+// The bold typographic style prop will apply fontWeight={1}
+<Text bold />
+
+// Strings can be used instead
+<Text fontWeight='bold' />
+
+// The shorthand `fw` prop can be used instead of `fontSize`
+<Text fw={1} />
+```
+
 ### Margin and Padding
 
 The margin and padding props make referencing steps on the spacing scale

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Like`fontSize`, the `fontWeight` prop allows you to easily reference steps on th
 // Strings can be used instead
 <Text fontWeight='bold' />
 
-// The shorthand `fw` prop can be used instead of `fontSize`
+// The shorthand `fw` prop can be used instead of `fontWeight`
 <Text fw={1} />
 ```
 

--- a/src/components.js
+++ b/src/components.js
@@ -18,12 +18,12 @@ import {
   darken,
   caps,
   align,
+  fontWeight,
+  bold,
 } from './util'
 import { Flex, Box } from './grid'
 import DonutBase from './DonutBase'
 import SelectBase from './SelectBase'
-
-const bold = props => idx('weights.1', props.theme)
 
 const components = [
   // Buttons
@@ -41,7 +41,7 @@ const components = [
     },
     style: props => ({
       fontFamily: 'inherit',
-      fontWeight: bold(props),
+      fontWeight: fontWeight(props) || bold(props),
       lineHeight: 16 / 14,
       display: 'inline-block',
       verticalAlign: 'middle',
@@ -141,7 +141,7 @@ const components = [
       display: 'inline-flex',
       alignItems: 'center',
       alignSelf: 'stretch',
-      fontWeight: bold(props),
+      fontWeight: fontWeight(props),
       textDecoration: 'none',
       whiteSpace: 'nowrap',
       color: 'inherit',
@@ -178,7 +178,7 @@ const components = [
     },
     style: props => Object.assign({
       textAlign: align(props),
-      fontWeight: props.bold ? bold(props) : idx('weights.0', props.theme)
+      fontWeight: fontWeight(props)
     }, caps(props)),
     propTypes: {
       left: bool,
@@ -614,7 +614,7 @@ const components = [
       p: 2,
     },
     style: props => ({
-      fontWeight: bold(props),
+      fontWeight: fontWeight(props),
       borderBottomWidth: px(1),
       borderBottomStyle: 'solid',
     })
@@ -627,7 +627,7 @@ const components = [
       p: 2,
     },
     style: props => ({
-      fontWeight: bold(props),
+      fontWeight: fontWeight(props),
       borderTopWidth: px(1),
       borderTopStyle: 'solid',
     })
@@ -674,7 +674,7 @@ const components = [
       display: 'flex',
       alignItems: 'center',
       minHeight: px(48),
-      fontWeight: bold(props)
+      fontWeight: fontWeight(props)
     })
   },
   {
@@ -726,7 +726,7 @@ const components = [
       bg: 'blue'
     },
     style: props => ({
-      fontWeight: bold(props),
+      fontWeight: fontWeight(props),
       display: 'inline-block',
       verticalAlign: 'middle',
       borderRadius: px(props.theme.radius)
@@ -788,7 +788,7 @@ const components = [
     },
     style: props => ({
       textDecoration: 'none',
-      fontWeight: bold(props),
+      fontWeight: fontWeight(props),
       color: props.active ? color(props)('blue') : 'inherit',
       borderBottomWidth: props.active ? 2 : 0,
       borderBottomStyle: 'solid',

--- a/src/hoc.js
+++ b/src/hoc.js
@@ -29,6 +29,8 @@ const propTypes = {
   w: prop,
   fontSize: prop,
   f: prop,
+  fontWeight: prop,
+  fw: prop,
   color: prop,
   bg: prop,
   m: prop,

--- a/src/util.js
+++ b/src/util.js
@@ -23,6 +23,17 @@ export const align = props => {
   return null
 }
 
+export const fontWeight = props => {
+  const fw = props.fw || props.fontWeight;
+  if (props.fw === 0 || props.fontWeight === 0) return idx('weights.0', props.theme)
+  if (props.bold) return idx('weights.1', props.theme)
+  if (typeof fw === 'string') return fw
+  if (typeof fw === 'number') return idx('weights.'+fw, props.theme)
+  return null
+}
+
+export const bold = props => idx('weights.1', props.theme)
+
 export default {
   idx,
   px,

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -46,6 +46,12 @@ storiesOf('Button', module)
       children='Hello'
     />
   ))
+  .add('Regular Font', () => (
+    <Button
+      fontWeight = {0}
+      children='Hello'
+    />
+  ))
   .add('Width', () => (
     <Button
       w={[ 1, 1/2 ]}


### PR DESCRIPTION
Add fontWeight() util
Relocate bold() to util
In components, use fontWeight() util instead of bold() in most cases - keep bold() as fallback for Button
Add fontWeight and fw props to hoc (are equivalent)
Add Regular Font story to Button
Add Font Weight section to README