### PR TITLE
Remove incorrect language about the Provider component

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,7 @@ This is useful for ensuring semantic markup, while keeping styles decoupled.
 ### `<Provider />`
 
 The `<Provider />` component is a wrapper around styled-components' [ThemeProvider](https://www.styled-components.com/docs/advanced#theming).
-It also provides global styles that remove the body tag's margin, sets all elements to `box-sizing: border-box`,
-and sets a default font-family value based on `theme.font`.
+It also sets a default font-family value based on `theme.font`.
 
 The Provider should be wrapped around a top-level component to ensure Rebass works as expected.
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,18 @@ const App = props => (
 )
 ```
 
+You'll likely want to add additional global styles that set `box-sizing: border-box` in your application.
+This can be done with styled-components [`injectGlobal`](https://www.styled-components.com/docs/api#injectglobal):
+
+```jsx
+import { injectGlobal } from 'styled-components'
+
+injectGlobal`
+  * { box-sizing: border-box; }
+  body { margin: 0; }
+`
+```
+
 ### UI Components
 
 For an interactive demo of all Rebass components, see http://jxnblk.com/rebass


### PR DESCRIPTION
This clarifies language in the README related to the `<Provider />` component. To keep the code base simple and unopinionated, the Provider component *does not* set any global styles.

Fixes #274 
