### PR TITLE
Add maxWidth to blacklisted props

### DIFF
--- a/src/style-props.js
+++ b/src/style-props.js
@@ -4,6 +4,7 @@
 export default [
   'width',
   'w',
+  'maxWidth',
   'fontSize',
   'f',
   'color',


### PR DESCRIPTION
Hi, thank you for this great lib!

This should fix the 'Unknown prop `maxWidth` on `<div>` tag' warning when setting the `maxWidth` prop on the `Container` component 😄 