### PR TITLE
Use extend for README customization demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,10 +359,9 @@ const App = props => (
 Rebass components can be completely customized using styled-components.
 
 ```jsx
-import styled from 'styled-components'
 import { Button } from 'rebass'
 
-const CustomButton = styled(Button)`
+const CustomButton = Button.extend`
   border: 1px solid rgba(0, 0, 0, .25);
   background-image: linear-gradient(transparent, rgba(0, 0, 0, .125));
   box-shadow: 0 0 4px rgba(0, 0, 0, .25)


### PR DESCRIPTION
styled-components [`.extend`](https://www.styled-components.com/docs/basics#extending-styles) overrides previous styles instead of creating a new style sheet, so it’s preferable here.