### PR TITLE
Use grid-styled/emotion in emotion version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,8 +10,16 @@
         [
           "transform-rename-import",
           {
-            "original": "^system-components$",
-            "replacement": "system-components/emotion"
+            "replacements": [
+              {
+                "original": "^system-components$",
+                "replacement": "system-components/emotion"
+              },
+              {
+                "original": "^grid-styled$",
+                "replacement": "grid-styled/emotion"
+              }
+            ]
           }
         ]
       ]


### PR DESCRIPTION
With the way it is right now, styled-components is still used since grid-styled is imported instead of grid-styled/emotion.

Also, once this is merged and released, I'll deprecate rebass-emotion.