### PR TITLE
Add fontFamily to Heading

### DIFF
--- a/src/Heading.js
+++ b/src/Heading.js
@@ -8,6 +8,7 @@ export const Heading = sys({
   lineHeight: 1.25,
   m: 0
 },
+  'fontFamily',
   'color',
   'textAlign'
 )

--- a/src/Text.js
+++ b/src/Text.js
@@ -5,6 +5,7 @@ export const Text = sys({
 },
   'space',
   'color',
+  'fontFamily',
   'fontSize',
   'fontWeight',
   'textAlign',


### PR DESCRIPTION
While it's easy enough to extend `Heading` to change the font, I imagine there are enough projects out there with different heading/body fonts to warrant including `fontFamily` here for convenience.