### PR TITLE
Replace chroma-js with polished

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "author": "Brent Jackson",
   "license": "MIT",
   "dependencies": {
-    "chroma-js": "^1.3.6",
     "grid-styled": "^4.2.0",
+    "polished": "^1.9.3",
     "prop-types": "^15.6.0",
     "styled-system": "^2.3.1",
     "system-components": "^2.2.1"

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,4 +1,4 @@
-import chroma from 'chroma-js'
+import { parseToHsl, hsl, getLuminance } from 'polished'
 
 const names = [
   'red',      // 0
@@ -34,24 +34,20 @@ export const createColors = base => {
     gray: '#eee'
   }
 
-  const color = chroma(base)
-  const [ hue, sat, lite ] = color.hsl()
+  const { hue, saturation, lightness } = parseToHsl(base)
   const hues = createHues(hue)
   hues.forEach(h => {
     const name = hueName(h)
-    const val = chroma.hsl(h, sat, lite)
-    colors[name] = val.hex()
+    colors[name] = hsl(h, saturation, lightness)
   })
 
   return colors
 }
 
 export const invertLuminance = base => {
-  const color = chroma(base)
-  const luminance = color.luminance()
-  const [ h, s ] = color.hsl()
-  const next = chroma.hsl(h, s, 1 - luminance)
-  return next.hex()
+  const luminance = getLuminance(base)
+  const { hue, saturation } = parseToHsl(base)
+  return hsl(hue, saturation, 1 - luminance)
 }
 
 export const colors = createColors('#06e')

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -3796,8 +3796,8 @@ exports[`exports a Container component 1`] = `
 exports[`exports a DarkMode component 1`] = `
 .c0 {
   box-sizing: border-box;
-  color: #ffffff;
-  background-color: #000000;
+  color: #fff;
+  background-color: #000;
 }
 
 <div


### PR DESCRIPTION
I noticed that one of the biggest parts of this library is `chroma-js` library, it is taking nearly [30% of the resulting package](https://bundlephobia.com/result?p=rebass@2.1.0)

I replaced `chroma-js` with [`polished`](https://polished.js.org/), which is smaller than `chroma-js` for about 5kb (min+gzip). No tests are changed as the behaviour of the `rebass` is not affected in any way, but one of the snapshots is updated as `polished` always minimizes hex colour output if possible (e.g. `#000000 -> #000`)

Another good thing about using `polished` is that when (if) `rebass` will provide proper es modules as a distribution, bundling tools like Webpack, Parcel or Rollup would be able to tree-shake unused `polished` dependencies, making the resulting package even smaller

ℹ️ This is just a suggestion. If this change is not needed, feel free to just close the PR 

