### PR TITLE
fix: prevent checkbox icon from shrinking on small width

### DIFF
--- a/packages/forms/src/index.js
+++ b/packages/forms/src/index.js
@@ -242,7 +242,9 @@ export const Checkbox= forwardRef(({
   variant = 'checkbox',
   ...props
 }, ref) =>
-  <Box>
+  <Box
+    sx={{ flexShrink: 0 }}
+  >
     <Box
       ref={ref}
       as='input'

--- a/packages/forms/test/__snapshots__/index.js.snap
+++ b/packages/forms/test/__snapshots__/index.js.snap
@@ -1,12 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkbox renders 1`] = `
-.emotion-3 {
-  box-sizing: border-box;
-  margin: 0;
-  min-width: 0;
-}
-
 .emotion-0 {
   box-sizing: border-box;
   margin: 0;
@@ -17,6 +11,15 @@ exports[`Checkbox renders 1`] = `
   width: 1px;
   height: 1px;
   overflow: hidden;
+}
+
+.emotion-3 {
+  box-sizing: border-box;
+  margin: 0;
+  min-width: 0;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
 .emotion-1 {


### PR DESCRIPTION
When the width for the Checkbox component is less than the label width Checkbox will shrink.
In this PR I just fix the problem with `flex-shrink:0`
before: 
![Screenshot from 2020-11-25 23-02-30](https://user-images.githubusercontent.com/3456305/100273932-db7b4c00-2f72-11eb-9a55-d2e7fd582a9a.png)

after:
![Screenshot from 2020-11-25 23-01-48](https://user-images.githubusercontent.com/3456305/100273937-dd450f80-2f72-11eb-81ac-b079594d872b.png)

