### PR TITLE
Update "getting starded" doc to use `@emotion/react`

### DIFF
--- a/packages/docs/src/pages/getting-started.mdx
+++ b/packages/docs/src/pages/getting-started.mdx
@@ -15,14 +15,14 @@ You can add a theme to your application with a `ThemeProvider` component and by 
 For this guide, use the Emotion `ThemeProvider` with the default Rebass preset theme.
 
 ```sh
-npm i @rebass/preset emotion-theming
+npm i @rebass/preset @emotion/react
 ```
 
 Wrap your application with the `ThemeProvider` component.
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from 'emotion-theming'
+import { ThemeProvider } from '@emotion/react'
 import theme from '@rebass/preset'
 
 export default props =>
@@ -128,7 +128,7 @@ Since Rebass follows the [Theme Specification][], any theme built for use with [
 
 ```jsx
 import React from 'react'
-import { ThemeProvider } from 'emotion-theming'
+import { ThemeProvider } from '@emotion/react'
 
 const theme = {
   fontSizes: [


### PR DESCRIPTION
https://www.npmjs.com/package/emotion-theming

`emotion-theming` has been removed and moved to `@emotion/react`

<img width="545" alt="Screen Shot 2022-03-17 at 2 09 48 PM" src="https://user-images.githubusercontent.com/3267066/158868861-af6b8804-d53f-4e0c-a548-580b84b720f0.png">

